### PR TITLE
Fix startup error: autoload `python--vhl-available`

### DIFF
--- a/python-x.el
+++ b/python-x.el
@@ -234,6 +234,7 @@ the python shell:
 statement for display purposes"
   (replace-regexp-in-string "\\s *\\\\\n\\s *" " " string))
 
+;;;###autoload
 (defvar python--vhl-available (if (require 'volatile-highlights nil t) t))
 
 ;;;###autoload


### PR DESCRIPTION
I used to get `void variable: python--vhl-available` when starting emacs. which I believe is due to : 

```
;;;###autoload
(defcustom python-multiline-highlight python--vhl-available
```
